### PR TITLE
Use SO_REUSEADDR and SO_REUSEPORT socket options to fix bind error

### DIFF
--- a/core/server.cpp
+++ b/core/server.cpp
@@ -42,6 +42,7 @@
 int createSocket(int port)
 {
 	int socket_fd;
+	int reuse = 1;
 	struct sockaddr_in server_addr;
 
 	//Create TCP Socket
@@ -51,6 +52,20 @@ int createSocket(int port)
 		perror("Server: error creating stream socket");
 		exit(1);
 	}
+
+    if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, (const char *)&reuse, sizeof(reuse)) < 0)
+    {
+        perror("Server: setsockopt(SO_REUSEADDR) failed");
+        exit(1);
+    }
+
+#ifdef SO_REUSEPORT
+    if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEPORT, (const char *)&reuse, sizeof(reuse)) < 0)
+    {
+        perror("Server: setsockopt(SO_REUSEPORT) failed");
+        exit(1);
+    }
+#endif
 
 	//Initialize Server Struct
 	bzero((char *) &server_addr, sizeof(server_addr));


### PR DESCRIPTION
When uploading a new program to OpenPLC, the openplc binary is killed and restarted. Binding to port 502 fails every time because the kill and respawn happens in quick succession. Manual intervention is therefore constantly needed.

Letting the socket reuse the address and port fixes this error. See: http://stackoverflow.com/a/25193462/239683