### PR TITLE
Add Dockerfile for building docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:8
+
+# Install dependencies
+RUN apt-get update
+RUN apt-get -y install sudo dos2unix build-essential pkg-config bison flex autoconf automake libtool make nodejs git
+
+COPY . /usr/local/src/OpenPLC
+WORKDIR /usr/local/src/OpenPLC
+
+# Convert windows type line endings
+RUN find . -type f -exec dos2unix {} \;
+
+# Build the OpenPLC project
+RUN echo "1" | bash /usr/local/src/OpenPLC/build.sh
+
+#Start the server
+CMD sudo nodejs server.js


### PR DESCRIPTION
Been playing around with OpenPLC_v2 and I managed to get it to build/run in a Docker container.  
This is great for the use case I am looking into as it makes it super portable and easy to spin up plc's on the fly.  

If you are unfamiliar with Docker, let me know and I can post detailed instructions for building and running the image.

If you decide to incorporate this pr, let me know where/what documentation should be updated and I can throw up another commit.

I have pushed the container to a dockerhub repository as jseed/openplc, for ease of access.  
I have yet to test it on any platform other than Docker for windows.  

The container needs to be run in privileged mode to allow for the realtime thread priority, and with the appropriate ports open.  Sample run command:
```
docker run -d --privileged -p 8080:8080 -p 502:502 jseed/openplc
```
